### PR TITLE
[MAINT] test on oldest and latest matlab

### DIFF
--- a/.github/workflows/run_tests_matlab.yml
+++ b/.github/workflows/run_tests_matlab.yml
@@ -21,10 +21,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        version: [R2021a, R2023b]
+        version: [R2021a, R2025b]
         include:
         - os: macos-latest
-          version: R2023b
+          version: R2025b
       fail-fast: false  # Don't cancel all jobs if one fails
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Adjust GitHub Actions MATLAB test matrix to replace R2023b with R2025b on Linux, Windows, and macOS.